### PR TITLE
Fixes...

### DIFF
--- a/classes/SettingsManager.php
+++ b/classes/SettingsManager.php
@@ -105,7 +105,7 @@ class SettingsManager {
 	private static function appendToSettingsFile($append, $filename='settings.inc.php')
 	{
 		$settings_content = self::getSettingsFileContents($filename);
-		$settings_content = '<?php' . $settings_content . $append . "\n";
+		$settings_content = '<?php' . $settings_content . "\n" . $append . "\n";
 		if (file_exists(MUMPHPI_MAINDIR.'/'.$filename)) {
 			file_put_contents(MUMPHPI_MAINDIR.'/'.$filename, $settings_content);
 		}


### PR DESCRIPTION
while using your web interface, I discovered that I could not change the aliases of virtual servers after setting them for the first time. I discovered that this is because the server settings ended up looking like this:

```
$servers[1]['name']              = 'foo';
$servers[1]['allowlogin']        = true;
$servers[1]['allowregistration'] = true;
$servers[1]['forcemail']         = true;
$servers[1]['authbymail']        = false;$servers[2]['name']              = 'bar';
$servers[2]['allowlogin']        = true;
$servers[2]['allowregistration'] = true;
$servers[2]['forcemail']         = true;
$servers[2]['authbymail']        = false;$servers[3]['name']              = 'baz';
// etc.
```

This should be fixed with my change.
