### PR TITLE
Sort order of channels

### DIFF
--- a/classes/ChannelViewerProtocolProducer.php
+++ b/classes/ChannelViewerProtocolProducer.php
@@ -26,6 +26,13 @@ class ChannelViewerProtocolProducer {
 		$subChansAsJson = array();
 		$subChannels = $tree->children;
 		if (!empty($subChannels)) {
+			$positions = array();
+			$names = array();
+			foreach ($subChannels as $key => $subChannel) {
+				$positions[$key] = $subChannel->c->position;
+				$names[$key] = $subChannel->c->name;
+			}
+			array_multisort($positions, SORT_ASC, SORT_NUMERIC, $names, SORT_ASC, SORT_STRING, $subChannels);
 			foreach ($subChannels as $subChannel) {
 				$subChansAsJson[] = $this->treeToJsonArray($subChannel);
 			}


### PR DESCRIPTION
Until now, Channels were displayed in the Mumble viewer without any sorting. This commit adds some code to ChannelViewerProtocolProducer to change that.

I am not quite sure whether this is the right place to sort the channels. Maybe you want to change it in MView.js instead, but I think returning the channels in their correct order also makes sense on the server side. Plus, it's probably more work to do the sorting in Javascript ;)
