### PR TITLE
Force Ice to use 1.0 encoding because Murmur (may) still use ICE 3.4

### DIFF
--- a/classes/ServerInterface.php
+++ b/classes/ServerInterface.php
@@ -104,6 +104,7 @@ class ServerInterface_ice
 		$initData = new Ice_InitializationData;
 		$initData->properties = Ice_createProperties();
 		$initData->properties->setProperty('Ice.ImplicitContext', 'Shared');
+		$initData->properties->setProperty('Ice.Default.EncodingVersion', '1.0');
 		$ICE = Ice_initialize($initData);
 		/*
 		 * getImplicitContext() is not implemented for icePHP yet…


### PR DESCRIPTION
If ICE is left to its own devices, it will use the default encoding for that version. I'm using PHPICE 3.5 and since (my) Murmur still uses 3.4 the 1.1 protocol pukes the server with the following message if we don't force the protocol to 1.0 for now:

```
-! 10/25/15 12:02:45.232 warning: dispatch exception: ../../include/Ice/BasicStream.h:175: Ice::UnsupportedEncodingException:
   protocol error: unsupported encoding version: 1.1
   (can only support encodings compatible with version 1.1)
   identity: Meta
   facet: 
   operation: ice_isA
   remote host: 127.0.0.1 remote port: 42330

```

Credit goes to this PR https://github.com/mumble-voip/mumble/issues/1252 for most of the work, I simply implemented it in MumPI

As they say, definitely not a complete solution, but a fantastic workaround for now, probably only worthwhile for Murmur 3.4+.

I'm using server snapshot ``1.3.0~745~g10c902f~snapshot`` and this works great.

edit: Clarified that the fact that Murmur is using 3.4 is my distro, not all Murmur instances